### PR TITLE
Cs beachcomb efficiency

### DIFF
--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -658,7 +658,7 @@ boolean sl_spoonTuneMoon();	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_beachCombAvailable();	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_canBeachCombHead(string name);	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_beachCombHead(string name);	// Defined in sl_ascend/sl_mr2019.ash
-int sl_beachCombFreeUsesLeft()	// Defined in sl_ascend/sl_mr2019.ash
+int sl_beachCombFreeUsesLeft();	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_beachUseFreeCombs();	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_campawayAvailable();	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_campawayGrabBuffs();	// Defined in sl_ascend/sl_mr2019.ash

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -658,6 +658,7 @@ boolean sl_spoonTuneMoon();	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_beachCombAvailable();	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_canBeachCombHead(string name);	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_beachCombHead(string name);	// Defined in sl_ascend/sl_mr2019.ash
+int sl_beachCombFreeUsesLeft()	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_beachUseFreeCombs();	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_campawayAvailable();	// Defined in sl_ascend/sl_mr2019.ash
 boolean sl_campawayGrabBuffs();	// Defined in sl_ascend/sl_mr2019.ash

--- a/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
+++ b/RELEASE/scripts/sl_ascend/sl_ascend_header.ash
@@ -486,6 +486,8 @@ boolean cs_preTurnStuff(int curQuest);						//Defined in sl_ascend/sl_community_
 void set_cs_questListFast(int[int] fast);					//Defined in sl_ascend/sl_community_service.ash
 boolean canTrySaberTrickMeteorShower();           //Defined in sl_ascend/sl_community_service.ash
 boolean trySaberTrickMeteorShower();              //Defined in sl_ascend/sl_community_service.ash
+int beachHeadTurnSavings(int quest);							//Defined in sl_ascend/sl_community_service.ash
+boolean tryBeachHeadBuff(int quest);							//Defined in sl_ascend/sl_community_service.ash
 
 boolean dealWithMilkOfMagnesium(boolean useAdv);			//Defined in sl_ascend/sl_cooking.ash
 void debugMaximize(string req, int meat);					//Defined in sl_ascend/sl_util.ash

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -5062,6 +5062,7 @@ int beachHeadTurnSavings(int quest){
 	return adv_savings - adv_cost;
 }
 
+# Note: sl_beachCombHead will only work if free walks are available, may want to change
 boolean tryBeachHeadBuff(int quest){
 	boolean success = false;
 	switch(quest){

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -5029,18 +5029,33 @@ int beachHeadTurnSavings(int quest){
 	switch(quest){
 	case 2: // every 30 bonus muscle saves 1 turn.
 		adv_savings = buffed_stat_savings($stat[muscle]);
+		if(have_effect($effect[Lack of Body-Building]) > 0){
+			adv_cost = 0;
+		}
 		break;
 	case 3: // every 30 bonus mysticality saves 1 turn
 		adv_savings = buffed_stat_savings($stat[mysticality]);
+		if(have_effect($effect[We're All Made of Starfish]) > 0){
+			adv_cost = 0;
+		}
 		break;
 	case 4: // every 30 bonus moxie saves 1 turn.
 		adv_savings = buffed_stat_savings($stat[moxie]);
+		if(have_effect($effect[Pomp & Circumsands]) > 0){
+			adv_cost = 0;
+		}
 		break;
 	case 5: // every 5 lbs saves 1 turn
 		adv_savings = 1;
+		if(have_effect($effect[Do I Know You From Somewhere?]) > 0){
+			adv_cost = 0;
+		}
 		break;
 	case 10: // every point of hot resistance saves 1 turn
 		adv_savings = 3;
+		if(have_effect($effect[Hot-Headed]) > 0){
+			adv_cost = 0;
+		}
 		break;
 	}
 

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -5043,17 +5043,29 @@ int beachHeadTurnSavings(int quest){
 }
 
 boolean tryBeachHeadBuff(int quest){
+	boolean success = false;
 	switch(quest){
 	case 2: // every 30 bonus muscle saves 1 turn.
-		return sl_beachCombHead("muscle");
+		success = sl_beachCombHead("muscle");
+		break;
 	case 3: // every 30 bonus mysticality saves 1 turn
-		return sl_beachCombHead("mysticality");
+		success = sl_beachCombHead("mysticality");
+		break;
 	case 4: // every 30 bonus moxie saves 1 turn.
-		return sl_beachCombHead("moxie");
+		success = sl_beachCombHead("moxie");
+		break;
 	case 5: // every 5 lbs saves 1 turn
-		return sl_beachCombHead("familiar");
+		success = sl_beachCombHead("familiar");
+		break;
 	case 10: // every point of hot resistance saves 1 turn
-		return sl_beachCombHead("hot");
+		success = sl_beachCombHead("hot");
+		break;
 	}
-	return false;
+	
+	if(success){
+		print("Got beach head buff, estimate savings " + beachHeadTurnSavings(quest) + " turns");
+	} else{
+		print("Wasnt able to get beach head buff.", "red");
+	}
+	return success;
 }

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -2817,6 +2817,10 @@ boolean LA_cs_communityService()
 
 			spacegateVaccine($effect[Rainbow Vaccine]);
 
+			if(get_cs_questCost(curQuest) > 1 && beachHeadTurnSavings(curQuest) > 0){
+				tryBeachHeadBuff(curQuest);
+			}
+
 			int curCost = get_cs_questCost(curQuest);
 
 			if((have_effect($effect[Synthesis: Hot]) == 0) && (curCost >= 6))
@@ -2830,9 +2834,7 @@ boolean LA_cs_communityService()
 				buffMaintain($effect[Spiro Gyro], 0, 1, 1);
 			}
 
-			if(curCost > 1 && beachHeadTurnSavings(curQuest) > 0){
-				tryBeachHeadBuff(curQuest);
-			}
+
 
 			cs_eat_stuff(curQuest);
 
@@ -4443,11 +4445,11 @@ int estimate_cs_questCost(int quest)
 	int retval = 60;
 	switch(quest)
 	{
-	case 1:		retval = 60 - ((my_maxhp() - (my_buffedstat($stat[Muscle]) + 3)) / 30);	break;
-	case 2:		retval = 60 - ((my_buffedstat($stat[Muscle]) - my_basestat($stat[Muscle])) / 30);	break;
-	case 3:		retval = 60 - ((my_buffedstat($stat[Mysticality]) - my_basestat($stat[Mysticality])) / 30);	break;
-	case 4:		retval = 60 - ((my_buffedstat($stat[Moxie]) - my_basestat($stat[Moxie])) / 30);	break;
-	case 5:		retval = 60 - ((weight_adjustment() + familiar_weight(my_familiar())) / 5);	break;
+	case 1:		retval = 60 - floor((my_maxhp() - (my_buffedstat($stat[Muscle]) + 3)) / 30);	break;
+	case 2:		retval = 60 - floor((my_buffedstat($stat[Muscle]) - my_basestat($stat[Muscle])) / 30);	break;
+	case 3:		retval = 60 - floor((my_buffedstat($stat[Mysticality]) - my_basestat($stat[Mysticality])) / 30);	break;
+	case 4:		retval = 60 - floor((my_buffedstat($stat[Moxie]) - my_basestat($stat[Moxie])) / 30);	break;
+	case 5:		retval = 60 - floor((weight_adjustment() + familiar_weight(my_familiar())) / 5);	break;
 	case 6:
 		if(have_effect($effect[Bow-Legged Swagger]) > 0)
 		{
@@ -5013,29 +5015,19 @@ int beachHeadTurnSavings(int quest){
 	int adv_savings = 0;
 	switch(quest){
 	case 2: // every 30 bonus muscle saves 1 turn.
-		if(sl_canBeachCombHead("muscle")){
-			adv_savings = buffed_stat_savings($stat[muscle]);
-		}
+		adv_savings = buffed_stat_savings($stat[muscle]);
 		break;
 	case 3: // every 30 bonus mysticality saves 1 turn
-		if(sl_canBeachCombHead("mysticality")){
-			adv_savings = buffed_stat_savings($stat[mysticality]);
-		}
+		adv_savings = buffed_stat_savings($stat[mysticality]);
 		break;
 	case 4: // every 30 bonus moxie saves 1 turn.
-		if(sl_canBeachCombHead("moxie")){
-			adv_savings = buffed_stat_savings($stat[moxie]);
-		}
+		adv_savings = buffed_stat_savings($stat[moxie]);
 		break;
 	case 5: // every 5 lbs saves 1 turn
-		if(sl_canBeachCombHead("familiar")){
-			adv_savings = 1;
-		}
+		adv_savings = 1;
 		break;
 	case 10: // every point of hot resistance saves 1 turn
-		if(sl_canBeachCombHead("hot")){
-			adv_savings = 3;
-		}
+		adv_savings = 3;
 		break;
 	}
 
@@ -5061,7 +5053,7 @@ boolean tryBeachHeadBuff(int quest){
 		success = sl_beachCombHead("hot");
 		break;
 	}
-	
+
 	if(success){
 		print("Got beach head buff, estimate savings " + beachHeadTurnSavings(quest) + " turns");
 	} else{

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -1603,6 +1603,12 @@ boolean LA_cs_communityService()
 			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Gr8tness], 0, 1, 1);
 			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Pill Power], 0, 1, 1);
 
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Pill Power], 0, 1, 1);
+
+			if(estimate_cs_questCost(curQuest) > 1 && beachHeadTurnSavings(curQuest) > 0){
+				tryBeachHeadBuff(curQuest);
+			}
+
 			int grapeCost = 1;
 			if(item_amount($item[Green Mana]) > 0)
 			{
@@ -1691,6 +1697,10 @@ boolean LA_cs_communityService()
 			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Experimental Effect G-9], 0, 1, 1);
 			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[The Magic Of LOV], 0, 1, 1);
 			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Seriously Mutated], 0, 1, 1);
+
+			if(estimate_cs_questCost(curQuest) > 1 && beachHeadTurnSavings(curQuest) > 0){
+				tryBeachHeadBuff(curQuest);
+			}
 
 			int grapeCost = 1;
 			if(item_amount($item[Green Mana]) > 0)
@@ -1794,6 +1804,10 @@ boolean LA_cs_communityService()
 			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[The Moxie Of LOV], 0, 1, 1);
 			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Seriously Mutated], 0, 1, 1);
 
+			if(estimate_cs_questCost(curQuest) > 1 && beachHeadTurnSavings(curQuest) > 0){
+				tryBeachHeadBuff(curQuest);
+			}
+
 			int grapeCost = 1;
 			if(item_amount($item[Green Mana]) > 0)
 			{
@@ -1896,6 +1910,10 @@ boolean LA_cs_communityService()
 				lastQuestCost = lastQuestCost - 3;
 			}
 
+			if(estimate_cs_questCost(curQuest) > 1 && beachHeadTurnSavings(curQuest) > 0){
+				tryBeachHeadBuff(curQuest);
+			}
+
 			buffMaintain($effect[Blue Swayed], 0, 1, 50);
 			buffMaintain($effect[Blue Swayed], 0, 1, 50);
 			buffMaintain($effect[Blue Swayed], 0, 1, 50);
@@ -1903,6 +1921,7 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[Blue Swayed], 0, 1, 50);
 			buffMaintain($effect[Loyal Tea], 0, 1, 1);
 			buffMaintain($effect[Blood Bond], 0, 1, 1);
+
 			if((spleen_left() > 0) && (item_amount($item[Abstraction: Joy]) > 0) && (have_effect($effect[Joy]) == 0))
 			{
 				slChew(1, $item[Abstraction: Joy]);
@@ -2809,6 +2828,10 @@ boolean LA_cs_communityService()
 			if(curCost >= 3)
 			{
 				buffMaintain($effect[Spiro Gyro], 0, 1, 1);
+			}
+
+			if(curCost > 1 && beachHeadTurnSavings(curQuest) > 0){
+				tryBeachHeadBuff(curQuest);
 			}
 
 			cs_eat_stuff(curQuest);
@@ -4971,4 +4994,66 @@ boolean trySaberTrickMeteorShower(){
 	boolean ret = slAdv(1, $location[The Dire Warren], "sl_saberTrickMeteorShowerCombatHandler");
 	resetMaximize();
 	return ret;
+}
+
+int beachHeadTurnSavings(int quest){
+	int buffed_stat_savings(stat s){
+		return floor(((my_basestat(s) * 1.5) - my_basestat(s))/30);
+	}
+
+	if(!sl_beachCombAvailable() || !($int[2, 3, 4, 5, 10] contains quest)){
+		return 0;
+	}
+
+	int adv_cost = 0;
+	if(sl_beachCombFreeUsesLeft() == 0){
+		adv_cost = 1;
+	}
+
+	int adv_savings = 0;
+	switch(quest){
+	case 2: // every 30 bonus muscle saves 1 turn.
+		if(sl_canBeachCombHead("muscle")){
+			adv_savings = buffed_stat_savings($stat[muscle]);
+		}
+		break;
+	case 3: // every 30 bonus mysticality saves 1 turn
+		if(sl_canBeachCombHead("mysticality")){
+			adv_savings = buffed_stat_savings($stat[mysticality]);
+		}
+		break;
+	case 4: // every 30 bonus moxie saves 1 turn.
+		if(sl_canBeachCombHead("moxie")){
+			adv_savings = buffed_stat_savings($stat[moxie]);
+		}
+		break;
+	case 5: // every 5 lbs saves 1 turn
+		if(sl_canBeachCombHead("familiar")){
+			adv_savings = 1;
+		}
+		break;
+	case 10: // every point of hot resistance saves 1 turn
+		if(sl_canBeachCombHead("hot")){
+			adv_savings = 3;
+		}
+		break;
+	}
+
+	return adv_savings - adv_cost;
+}
+
+boolean tryBeachHeadBuff(int quest){
+	switch(quest){
+	case 2: // every 30 bonus muscle saves 1 turn.
+		return sl_beachCombHead("muscle");
+	case 3: // every 30 bonus mysticality saves 1 turn
+		return sl_beachCombHead("mysticality");
+	case 4: // every 30 bonus moxie saves 1 turn.
+		return sl_beachCombHead("moxie");
+	case 5: // every 5 lbs saves 1 turn
+		return sl_beachCombHead("familiar");
+	case 10: // every point of hot resistance saves 1 turn
+		return sl_beachCombHead("hot");
+	}
+	return false;
 }

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -3,6 +3,19 @@ script "sl_community_service.ash"
 #	Some details derived some yojimbos_law's forum post:
 #	http://forums.kingdomofloathing.com/vb/showpost.php?p=4769933&postcount=345
 
+# TODO:
+#   - blood bond + completing CS quest can cause HP to drop to 0 and break the script
+#		- add power leveling at NEP (free fights) to reach level 4 for agua de vida
+#		- add run NEP (free fights) when low on meat to afford hot dogs/speakeasy drinks
+#		- add beach comb (free) for meat (some sea vegetables sell for 350 each)
+# 	- get cloud buff before power leveling/NEP
+#		- free rests at campsite
+#		- add flag to ignore that damn fortune cookie counter
+#		- early level combat can sometimes get stuck from low mp (free camp site rests might help)
+#		- saving emergency marg message end of day 1 is misleading (says to overdrink then cast simmer)
+#		- fill stomach/spleen/liver at the end of day 1
+#		- day 2, try to get pokefam +10 lb weight item from grass with extra pokegrow fertilizer
+
 static int[int] sl_cs_fastQuestList;
 
 boolean LA_cs_communityService()
@@ -5038,24 +5051,29 @@ boolean tryBeachHeadBuff(int quest){
 	boolean success = false;
 	switch(quest){
 	case 2: // every 30 bonus muscle saves 1 turn.
-		success = sl_beachCombHead("muscle");
+		sl_beachCombHead("muscle");
+		success = have_effect($effect[Lack of Body-Building]) > 0;
 		break;
 	case 3: // every 30 bonus mysticality saves 1 turn
-		success = sl_beachCombHead("mysticality");
+		sl_beachCombHead("mysticality");
+		success = have_effect($effect[We're All Made of Starfish]) > 0;
 		break;
 	case 4: // every 30 bonus moxie saves 1 turn.
-		success = sl_beachCombHead("moxie");
+		sl_beachCombHead("moxie");
+		success = have_effect($effect[Pomp & Circumsands]) > 0;
 		break;
 	case 5: // every 5 lbs saves 1 turn
-		success = sl_beachCombHead("familiar");
+		sl_beachCombHead("familiar");
+		success = have_effect($effect[Do I Know You From Somewhere?]) > 0;
 		break;
 	case 10: // every point of hot resistance saves 1 turn
-		success = sl_beachCombHead("hot");
+		sl_beachCombHead("hot");
+		success = have_effect($effect[Hot-Headed]) > 0;
 		break;
 	}
 
 	if(success){
-		print("Got beach head buff, estimate savings " + beachHeadTurnSavings(quest) + " turns");
+		print("Have beach head buff, estimate savings " + beachHeadTurnSavings(quest) + " turns");
 	} else{
 		print("Wasnt able to get beach head buff.", "red");
 	}

--- a/RELEASE/scripts/sl_ascend/sl_community_service.ash
+++ b/RELEASE/scripts/sl_ascend/sl_community_service.ash
@@ -5001,7 +5001,7 @@ int beachHeadTurnSavings(int quest){
 		return floor(((my_basestat(s) * 1.5) - my_basestat(s))/30);
 	}
 
-	if(!sl_beachCombAvailable() || !($int[2, 3, 4, 5, 10] contains quest)){
+	if(!sl_beachCombAvailable() || !($ints[2, 3, 4, 5, 10] contains quest)){
 		return 0;
 	}
 

--- a/RELEASE/scripts/sl_ascend/sl_mr2019.ash
+++ b/RELEASE/scripts/sl_ascend/sl_mr2019.ash
@@ -189,7 +189,7 @@ boolean sl_sausageGoblin(location loc, string option)
 		return false;
 	}
 
-	// My (Malibu Stacey) and Ezandora's spading appears to guarantee the first 
+	// My (Malibu Stacey) and Ezandora's spading appears to guarantee the first
 	// 7 sausage goblins using a formula of 3n+1 adventures since the previous.
 	// After that, you're on your own (hey it's better than nothing).
 	// Also that doesn't apply to the first goblin, it's always 100%.
@@ -624,6 +624,13 @@ boolean sl_beachCombHead(string name)
 	if(!sl_canBeachCombHead(name)) return false;
 
 	return cli_execute("beach head " + sl_beachCombHeadNumFrom(name));
+}
+
+int sl_beachCombFreeUsesLeft(){
+	if(!sl_beachCombAvailable() || get_property("_freeBeachWalksUsed").to_int() >= 11){
+		return 0;
+	}
+	return 11 - get_property("_freeBeachWalksUsed").to_int();
 }
 
 boolean sl_beachUseFreeCombs() {


### PR DESCRIPTION
Get beach head buffs for mus, myst, mox, hot and familiar weight CS quests. For some reason it often fails to get the beach head buff but I think this is a bug in mafia right now so calling it for now since the working ones prove the others will work one day. probably.